### PR TITLE
メモ新規作成機能追加

### DIFF
--- a/docs/api/reference/models/memo.v1.json
+++ b/docs/api/reference/models/memo.v1.json
@@ -44,6 +44,8 @@
   },
   "required": [
     "memo_id",
+    "title",
+    "content",
     "created_at",
     "updated_at"
   ]

--- a/docs/erd.vuerd.json
+++ b/docs/erd.vuerd.json
@@ -90,12 +90,12 @@
             "name": "title",
             "comment": "メモタイトル",
             "dataType": "VARCHAR(100)",
-            "default": "NULL",
+            "default": "\"\"",
             "option": {
               "autoIncrement": false,
               "primaryKey": false,
               "unique": false,
-              "notNull": false
+              "notNull": true
             },
             "ui": {
               "active": false,
@@ -113,12 +113,12 @@
             "name": "content",
             "comment": "メモ内容",
             "dataType": "TEXT",
-            "default": "NULL",
+            "default": "\"\"",
             "option": {
               "autoIncrement": false,
               "primaryKey": false,
               "unique": false,
-              "notNull": false
+              "notNull": true
             },
             "ui": {
               "active": false,
@@ -183,7 +183,7 @@
           "active": false,
           "left": 713.5999999999999,
           "top": 246.40000000000026,
-          "zIndex": 362,
+          "zIndex": 385,
           "widthName": 60,
           "widthComment": 60
         },

--- a/src/app/Http/Controllers/MemoController.php
+++ b/src/app/Http/Controllers/MemoController.php
@@ -58,9 +58,8 @@ class MemoController extends Controller
      */
     public function create(MemoRequest $request)
     {
-        $memo = new Memo();
-        $memo->title = $request->title;
-        $memo->content = $request->content;
+        // パラメータは直接使うのでなく、フォームリクエストで加工したものを使う
+        $memo = new Memo($request->validated());
 
         /** @var App\User $user */
         $user = Auth::user();

--- a/src/app/Http/Controllers/MemoController.php
+++ b/src/app/Http/Controllers/MemoController.php
@@ -84,9 +84,8 @@ class MemoController extends Controller
             return abort(404);
         };
 
-        $memo->title = $request->title;
-        $memo->content = $request->content;
-        $memo->save();
+        // パラメータは直接使うのでなく、フォームリクエストで加工したものを使う
+        $memo->update($request->validated());
 
         return response($memo, 200);
     }

--- a/src/app/Http/Requests/MemoRequest.php
+++ b/src/app/Http/Requests/MemoRequest.php
@@ -17,6 +17,26 @@ class MemoRequest extends FormRequest
     }
 
     /**
+     * Get data to be validated from the request.
+     *
+     * @return array
+     */
+    public function validationData()
+    {
+        $all = parent::validationData();
+
+        // 値がnullの時は空文字を入れる
+        if (is_null($all['title'])) {
+            $all['title'] = '';
+        }
+        if (is_null($all['content'])) {
+            $all['content'] = '';
+        }
+
+        return $all;
+    }
+
+    /**
      * Get the validation rules that apply to the request.
      *
      * @return array
@@ -24,8 +44,8 @@ class MemoRequest extends FormRequest
     public function rules()
     {
         return [
-            'title' => 'string|max:100',
-            'content' => 'string|max:65535'
+            'title' => 'present|string|max:100',
+            'content' => 'present|string|max:65535'
         ];
     }
 

--- a/src/database/migrations/2021_04_03_152417_change_not_null_memos_table.php
+++ b/src/database/migrations/2021_04_03_152417_change_not_null_memos_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeNotNullMemosTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('memos', function (Blueprint $table) {
+            // null許容からnot null（デフォルト空文字）へ
+            $table->string('title', 100)->nullable(false)->default('')->comment('メモタイトル')->change();
+            $table->text('content')->nullable(false)->default('')->comment('メモ内容')->change(); // 65535文字
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('memos', function (Blueprint $table) {
+            $table->string('title', 100)->nullable()->comment('メモタイトル')->change();
+            $table->text('content')->nullable()->comment('メモ内容')->change(); // 65535文字
+        });
+    }
+}

--- a/src/public/mix-manifest.json
+++ b/src/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=45b5dc453ebeee583ac2",
+    "/js/app.js": "/js/app.js?id=aac721ef1ba663ece515",
     "/css/app.css": "/css/app.css?id=af2dc2a82d7e9d5e698b"
 }

--- a/src/resources/ts/components/molecules/MemoListItem.tsx
+++ b/src/resources/ts/components/molecules/MemoListItem.tsx
@@ -22,7 +22,7 @@ const MemoListItem: FC<Props> = ({
     <ListItemIcon>
       <AssignmentIcon />
     </ListItemIcon>
-    <Box overflow="hidden">
+    <Box height={54} overflow="hidden">
       <ListItemText
         primary={title}
         secondary={content}

--- a/src/resources/ts/containers/organisms/MemoList.tsx
+++ b/src/resources/ts/containers/organisms/MemoList.tsx
@@ -3,7 +3,7 @@ import { useHistory } from 'react-router-dom';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { useTheme } from '@material-ui/core/styles';
 import MemoList from '../../components/organisms/MemoList';
-import { useGetMemoListQuery } from '../../hooks/memo';
+import { useGetMemoListQuery, usePostMemoMutation } from '../../hooks/memo';
 import { useIntersectionObserver } from '../../hooks/util';
 
 type Props = {
@@ -18,7 +18,9 @@ const EnhancedMemoList: FC<Props> = ({ memoId }) => {
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
-  } = useGetMemoListQuery();
+  } = useGetMemoListQuery({
+    refetchInterval: 1000,
+  });
   const history = useHistory();
   const statusCode = error?.response?.status;
 
@@ -32,15 +34,16 @@ const EnhancedMemoList: FC<Props> = ({ memoId }) => {
     }
   }, [history, paginateMemos, memoId, iswideDisplay]);
 
+  // 無限スクロール処理
   const { loadMoreRef } = useIntersectionObserver({
     onIntersect: fetchNextPage,
     enabled: hasNextPage,
   });
 
+  const { mutate } = usePostMemoMutation();
   const handleAddMemo = useCallback(() => {
-    // 仮
-    console.log('Add Memo');
-  }, []);
+    mutate({ title: '', content: '' });
+  }, [mutate]);
 
   const handleSelectItem = useCallback(
     (selectMemoId: string) => {

--- a/src/resources/ts/hooks/memo/index.ts
+++ b/src/resources/ts/hooks/memo/index.ts
@@ -1,2 +1,3 @@
 export { default as useGetMemoListQuery } from './useGetMemoListQuery';
 export { default as useGetMemoQuery } from './useGetMemoQuery';
+export { default as usePostMemoMutation } from './usePostMemoMutation';

--- a/src/resources/ts/hooks/memo/usePostMemoMutation.ts
+++ b/src/resources/ts/hooks/memo/usePostMemoMutation.ts
@@ -1,0 +1,30 @@
+import { useQueryClient, UseMutationResult, useMutation } from 'react-query';
+import axios, { AxiosError } from 'axios';
+import { Memo } from '../../models/Memo';
+
+type MemoData = {
+  title: string;
+  content: string;
+};
+
+const createMemo = async (memoData: MemoData): Promise<Memo> => {
+  const { data } = await axios.post('api/memos', memoData);
+  return data;
+};
+
+const usePostMemoMutation = (): UseMutationResult<
+  Memo,
+  AxiosError,
+  MemoData,
+  undefined
+> => {
+  const queryClient = useQueryClient();
+
+  return useMutation(createMemo, {
+    onSuccess: () => {
+      queryClient.invalidateQueries('memos');
+    },
+  });
+};
+
+export default usePostMemoMutation;

--- a/src/tests/Feature/memos/MemoCreateApiTest.php
+++ b/src/tests/Feature/memos/MemoCreateApiTest.php
@@ -50,6 +50,37 @@ class MemoCreateApiTest extends TestCase
 
     /**
      * @test
+     * 空文字パラメータの時、メモ情報を新規作成できるか
+     *
+     * 空文字パラメータは、API側で受け取るとConvertEmptyStringsToNullミドルウェアによりnullに変換される
+     * それをフォームリクエストで空文字に再変換して保存しているので、そのテスト
+     */
+    public function testPostMemoNullData()
+    {
+        $data = [
+            'title' => '',
+            'content' => ''
+        ];
+
+        $response = $this->actingAs($this->user)->json('POST', route('memo.create'), $data);
+
+        $memo = Memo::first();
+        $this->assertEquals($this->user->user_id, $memo->user_id);
+        $this->assertEquals($data['title'], $memo->title);
+        $this->assertEquals($data['content'], $memo->content);
+
+        $response->assertStatus(201)
+            ->assertJson([
+                'memo_id' => $memo->memo_id,
+                'title' => $memo->title,
+                'content' => $memo->content,
+                'created_at' => $memo->created_at->format(self::DATE_TIME_FORMAT),
+                'updated_at' => $memo->updated_at->format(self::DATE_TIME_FORMAT),
+            ]);
+    }
+
+    /**
+     * @test
      * バリデーションエラー時は422になるか
      */
     public function testPostMemoValidate()

--- a/src/tests/Unit/Requests/MemoRequestTest.php
+++ b/src/tests/Unit/Requests/MemoRequestTest.php
@@ -38,9 +38,24 @@ class MemoRequestTest extends TestCase
                 ['テスト タイトル', 'テスト 内容'],
                 false
             ],
+            'OK:空文字' => [
+                ['title', 'content'],
+                ['', ''],
+                false
+            ],
+            'NG:titleが存在しない' => [
+                ['content'],
+                ['テスト 内容'],
+                true
+            ],
             'NG:titleが文字列でない' => [
                 ['title', 'content'],
                 [123, 'テスト 内容'],
+                true
+            ],
+            'NG:titleがnull' => [
+                ['title', 'content'],
+                [null, 'テスト 内容'],
                 true
             ],
             'OK:titleが100文字以内' => [
@@ -53,9 +68,19 @@ class MemoRequestTest extends TestCase
                 [str_repeat('a', 101), 'テスト 内容'],
                 true
             ],
+            'NG:contentが存在しない' => [
+                ['title'],
+                ['テスト タイトル'],
+                true
+            ],
             'NG:contentが文字列でない' => [
                 ['title', 'content'],
                 ['テスト タイトル', 123],
+                true
+            ],
+            'NG:contentがnull' => [
+                ['title', 'content'],
+                ['テスト タイトル', null],
                 true
             ],
             'OK:contentが65535文字以内' => [


### PR DESCRIPTION
## Issue番号
#closes #43

## 対応内容
- メモ作成・編集 API の修正（空文字保存できるように）
- memos テーブルの title と content を NOT NULL に変更
- メモ作成 API を使ったカスタムフック作成
- メモ作成成功時に、メモ一覧の再取得処理をする
- そのカスタムフックでメモ新規作成処理を作る