### PR TITLE
初期データのseederを用意、メモ一覧取得 API 修正、ログアウト時の全クエリキャッシュクリア

### DIFF
--- a/docs/api/reference/ooui-memo.v1.yaml
+++ b/docs/api/reference/ooui-memo.v1.yaml
@@ -25,7 +25,7 @@ paths:
         - $ref: '#/components/parameters/XSRF-TOKEN'
         - $ref: '#/components/parameters/page'
       description: |
-        （ログインユーザの）メモ一覧取得API（1ページつき50件）
+        （ログインユーザの）メモ一覧取得API（1ページつき30件）
     post:
       summary: POST Memo
       operationId: post-memos

--- a/src/app/Http/Controllers/MemoController.php
+++ b/src/app/Http/Controllers/MemoController.php
@@ -27,7 +27,7 @@ class MemoController extends Controller
     public function index()
     {
         $user = Auth::user();
-        $memos = Memo::where('user_id', $user->user_id)->orderBy(Memo::UPDATED_AT, 'desc')->paginate(50);
+        $memos = Memo::where('user_id', $user->user_id)->orderBy(Memo::UPDATED_AT, 'desc')->paginate(30);
 
         return $memos;
     }

--- a/src/database/seeds/DatabaseSeeder.php
+++ b/src/database/seeds/DatabaseSeeder.php
@@ -11,6 +11,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call(UsersTableSeeder::class);
+        $this->call(UsersTableSeeder::class);
     }
 }

--- a/src/database/seeds/UsersTableSeeder.php
+++ b/src/database/seeds/UsersTableSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class UsersTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        factory(App\User::class)->create([
+            'name' => 'ooui-memo user',
+            'email' => 'dummy@email.com',
+            'password' => Hash::make('test1234'),
+        ])->each(function ($user) {
+            $user->memos()->saveMany(factory(App\Memo::class, 35)->make());
+        });
+    }
+}

--- a/src/public/mix-manifest.json
+++ b/src/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=ffe34071068e5edd3e44",
+    "/js/app.js": "/js/app.js?id=a37bc95931b6c4b593f3",
     "/css/app.css": "/css/app.css?id=af2dc2a82d7e9d5e698b"
 }

--- a/src/resources/ts/hooks/auth/useLogout.ts
+++ b/src/resources/ts/hooks/auth/useLogout.ts
@@ -2,8 +2,7 @@ import { useQueryClient, UseMutationResult, useMutation } from 'react-query';
 import axios, { AxiosError } from 'axios';
 
 const logout = async (): Promise<void> => {
-  const { data } = await axios.post('/api/logout');
-  return data;
+  await axios.post('/api/logout');
 };
 
 const useLogout = (): UseMutationResult<void, AxiosError, void, undefined> => {
@@ -11,7 +10,7 @@ const useLogout = (): UseMutationResult<void, AxiosError, void, undefined> => {
 
   return useMutation(logout, {
     onSuccess: () => {
-      queryClient.resetQueries('user');
+      queryClient.clear();
     },
   });
 };

--- a/src/resources/ts/hooks/memo/useDeleteMemoMutation.ts
+++ b/src/resources/ts/hooks/memo/useDeleteMemoMutation.ts
@@ -2,8 +2,7 @@ import { useQueryClient, UseMutationResult, useMutation } from 'react-query';
 import axios, { AxiosError } from 'axios';
 
 const deleteMemo = async (memoId: string): Promise<void> => {
-  const { data } = await axios.delete(`/api/memos/${memoId}`);
-  return data;
+  await axios.delete(`/api/memos/${memoId}`);
 };
 
 const useDeleteMemoMutation = (): UseMutationResult<

--- a/src/tests/Feature/memos/MemoListApiTest.php
+++ b/src/tests/Feature/memos/MemoListApiTest.php
@@ -69,17 +69,17 @@ class MemoListApiTest extends TestCase
      */
     public function testGetMemoListPages()
     {
-        factory(Memo::class, 52)->create(['user_id' => $this->auth_user->user_id]);
+        factory(Memo::class, 32)->create(['user_id' => $this->auth_user->user_id]);
 
         // 1ページ目
         $response = $this->actingAs($this->auth_user)->json('GET', route('memo.index'));
 
-        $memos = Memo::where('user_id', $this->auth_user->user_id)->orderBy('updated_at', 'desc')->limit(50)->get();
+        $memos = Memo::where('user_id', $this->auth_user->user_id)->orderBy('updated_at', 'desc')->limit(30)->get();
 
         $expected_data_first = $this->setExpectedData($memos);
 
         $response->assertStatus(200)
-            ->assertJsonCount(50, 'data')
+            ->assertJsonCount(30, 'data')
             ->assertJsonFragment([
                 "data" => $expected_data_first,
             ]);
@@ -89,8 +89,8 @@ class MemoListApiTest extends TestCase
 
         $memos = Memo::where('user_id', $this->auth_user->user_id)
             ->orderBy('updated_at', 'desc')
-            ->offset(50)
-            ->limit(50)
+            ->offset(30)
+            ->limit(30)
             ->get();
 
         $expected_data_second = $this->setExpectedData($memos);


### PR DESCRIPTION
## Issue番号
closes #53

## 対応内容
- users と memos の seeder を用意する（1ファイルでまとめて作成）

その他
- メモ一覧取得 API の1ページ当たり件数を30に変更
- ログアウト時に全てのクエリキャッシュをクリアするよう修正