### PR TITLE
一番新しいメモを削除した場合に、そのメモIDを選択したままになってしまう問題解消

### DIFF
--- a/src/public/mix-manifest.json
+++ b/src/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=a37bc95931b6c4b593f3",
+    "/js/app.js": "/js/app.js?id=8b0e29b48aa48e50b528",
     "/css/app.css": "/css/app.css?id=af2dc2a82d7e9d5e698b"
 }

--- a/src/resources/ts/containers/organisms/MemoList.tsx
+++ b/src/resources/ts/containers/organisms/MemoList.tsx
@@ -12,6 +12,7 @@ type Props = {
 
 const EnhancedMemoList: FC<Props> = ({ memoId }) => {
   const {
+    isFetching,
     isLoading,
     error,
     data: paginateMemos,
@@ -22,15 +23,15 @@ const EnhancedMemoList: FC<Props> = ({ memoId }) => {
   const history = useHistory();
   const statusCode = error?.response?.status;
 
-  // 画面幅が広い + メモ未選択時は、メモ一覧の一番新しいメモへ遷移
+  // データ取得中でない + 画面幅が広い + メモ未選択時は、メモ一覧の一番新しいメモへ遷移
   const theme = useTheme();
   const iswideDisplay = useMediaQuery(theme.breakpoints.up('sm'));
   useEffect(() => {
     const firstMemoId = paginateMemos?.pages[0]?.data[0].memoId;
-    if (!memoId && iswideDisplay && firstMemoId) {
+    if (!isFetching && !memoId && iswideDisplay && firstMemoId) {
       history.push(`/${firstMemoId}`);
     }
-  }, [history, paginateMemos, memoId, iswideDisplay]);
+  }, [history, isFetching, paginateMemos, memoId, iswideDisplay]);
 
   // 無限スクロール処理
   const { loadMoreRef } = useIntersectionObserver({


### PR DESCRIPTION
## Issue番号
closes #55 

## 対応内容
- データ取得中は最新メモへの遷移を動作しないように修正