### PR TITLE
メモ詳細で、メモが1つもない時は簡単な案内表示を出すようにする

### DIFF
--- a/src/public/mix-manifest.json
+++ b/src/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=21f8b873e8fe906aedd3",
+    "/js/app.js": "/js/app.js?id=8276cad184eeef0c7631",
     "/css/app.css": "/css/app.css?id=af2dc2a82d7e9d5e698b"
 }

--- a/src/resources/ts/components/organisms/MemoDetail.tsx
+++ b/src/resources/ts/components/organisms/MemoDetail.tsx
@@ -3,6 +3,7 @@ import Box from '@material-ui/core/Box';
 import Input from '@material-ui/core/Input';
 import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
+import Typography from '@material-ui/core/Typography';
 import { useTheme } from '@material-ui/core/styles';
 import Skeleton from '@material-ui/lab/Skeleton';
 import GeneralAlert from '../atoms/GeneralAlert';
@@ -54,7 +55,29 @@ const MemoDetail: FC<Props> = ({
     setIsDeleteDialogOpen(false);
   }, []);
 
-  if (isIdle || isLoading) {
+  // メモが1つもない用の簡単な案内表示
+  if (isIdle) {
+    return (
+      <>
+        <Box height={48} px={2} />
+        <Box
+          height={1}
+          py={2}
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Typography paragraph>
+            OOUI-MEMOへようこそ！
+            <br />
+            +ボタンから新しいメモが作成できます
+          </Typography>
+        </Box>
+      </>
+    );
+  }
+
+  if (isLoading) {
     return (
       <>
         <Box height={48} px={2} />


### PR DESCRIPTION
## Issue番号
closes #80

## 対応内容
‐ メモ詳細で、メモが1つもない時は簡単な案内表示を出すようにした

メモが1つでもあれば、メモ未選択時に最新のメモ選択状態に遷移するが
メモが1つもないと、遷移を発生させないため。
ずっとスケルトンを表示するのも変なので、簡単な案内表示を出すようにした。